### PR TITLE
Add toddler mode setting with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -335,6 +335,9 @@
         <select id="artSelect"><option value="pixel">Pixel</option><option value="classic">Classic</option></select>
       </label>
       <label class="field"><span>CRT Scanlines</span><input type="checkbox" id="scanlinesToggle" checked/></label>
+      <label class="field"><span>Toddler Mode</span>
+        <input type="checkbox" id="toddlerToggle"/>
+      </label>
       <div class="row"><button id="saveSettings" class="primary">Save</button><button id="resetApp" class="danger">Reset app</button></div>
     </section>
   </template>


### PR DESCRIPTION
## Summary
- add `settings.toddler` to persistent state with load/save support
- expose toddler mode toggle in settings UI
- toggle updates toddler mode, syncs coop week, and refreshes quests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70feb2ba883268400c165d414a6f5