### PR TITLE
feat: add toddler mode styling

### DIFF
--- a/app.js
+++ b/app.js
@@ -108,6 +108,7 @@ function applyTheme(){
 }
 applyTheme();
 function renderHUD(){
+  document.body.classList.toggle('toddler-on', state.settings.toddler);
   const cur=2; $("#hudHearts").innerHTML = Array.from({length:3},(_,i)=>`<span class="heart ${i<cur?'':'off'}"></span>`).join("");
   const lvl=state.pet.level, xp=state.pet.xp, next=xpForLevel(lvl+1), prev=xpForLevel(lvl);
   const pct = Math.max(0, Math.min(100, Math.round(((xp-prev)/(next-prev))*100)));

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,7 @@
 html,body{ height:100% }
 body{ margin:0; background:var(--bg); color:var(--text); display:flex; flex-direction:column; min-height:100vh;
       font-family:'Press Start 2P', monospace; letter-spacing:.5px; -webkit-font-smoothing:none; image-rendering: pixelated; }
+body.toddler-on{ background:#fff8f0; font-size:1.25em; }
 .app-header{ position:sticky; top:0; z-index:10; padding:.35rem .6rem; border-bottom:1px solid rgba(255,255,255,.06);
   background: linear-gradient(0deg, rgba(0,0,0,.65), rgba(0,0,0,.2)); }
 .brand{ display:flex; align-items:center; gap:.6rem }


### PR DESCRIPTION
## Summary
- Add `.toddler-on` body style with pastel background and larger fonts
- Toggle body `toddler-on` class in `renderHUD` based on settings

## Testing
- `node --check app.js && echo OK`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70ff182a8832697fb6e737155d6cd