### PR TITLE
Add toddler-friendly pet interactions

### DIFF
--- a/app.js
+++ b/app.js
@@ -396,10 +396,37 @@ function initPet(){
   stage.innerHTML = `<div class="pet">${petMarkup}</div>`;
   const xp=state.pet.xp, lvl=state.pet.level, next=xpForLevel(lvl+1);
   $("#petStats").textContent = `Level ${lvl} — ${xp}/${next} XP`;
-  $("#petName").value = state.pet.name; $("#petSpecies").value = state.pet.species;
-  $("#savePet").addEventListener("click",()=>{ state.pet.name=$("#petName").value.trim()||"Pebble"; state.pet.species=$("#petSpecies").value; saveState(state); initPet(); renderHUD(); });
-  const acc=Array.from(new Set([...(state.economy.ownedAcc||[]), 'cap','glasses'])); const accList=$("#accList"); accList.replaceChildren();
-  acc.forEach(a=>{ const btn=el("button",{className: state.pet.acc.includes(a)? "":"secondary", textContent:a}); btn.addEventListener("click",()=>{ const i=state.pet.acc.indexOf(a); if(i>=0) state.pet.acc.splice(i,1); else state.pet.acc.push(a); saveState(state); initPet(); }); accList.appendChild(btn); });
+
+  const nameInput=$("#petName"), speciesInput=$("#petSpecies"), saveBtn=$("#savePet"), accList=$("#accList");
+  const editRow=saveBtn?.closest('.row');
+  const accDetails=accList?.closest('details');
+  const toddler=state.settings?.toddler;
+
+  nameInput.value=state.pet.name;
+  speciesInput.value=state.pet.species;
+
+  if(toddler){
+    if(editRow) editRow.style.display='none';
+    if(accDetails) accDetails.style.display='none';
+    accList?.replaceChildren();
+    document.getElementById('toddlerActions')?.remove();
+    const actions=el('div',{id:'toddlerActions',className:'toddler-actions'},[
+      el('button',{className:'primary',textContent:'Feed'}),
+      el('button',{className:'primary',textContent:'Play'})
+    ]);
+    if(accDetails) accDetails.insertAdjacentElement('afterend',actions); else stage.insertAdjacentElement('afterend',actions);
+    const [feedBtn,playBtn]=actions.querySelectorAll('button');
+    feedBtn.addEventListener('click',()=>{ addXP(state,1); addGold(1); initPet(); renderHUD(); });
+    playBtn.addEventListener('click',()=>{ addXP(state,1); addGold(1); initPet(); renderHUD(); });
+  } else {
+    if(editRow) editRow.style.display='';
+    if(accDetails) accDetails.style.display='';
+    document.getElementById('toddlerActions')?.remove();
+    saveBtn.onclick=()=>{ state.pet.name=nameInput.value.trim()||"Pebble"; state.pet.species=speciesInput.value; saveState(state); initPet(); renderHUD(); };
+    const acc=Array.from(new Set([...(state.economy.ownedAcc||[]), 'cap','glasses']));
+    accList.replaceChildren();
+    acc.forEach(a=>{ const btn=el('button',{className: state.pet.acc.includes(a)? "":"secondary", textContent:a}); btn.addEventListener('click',()=>{ const i=state.pet.acc.indexOf(a); if(i>=0) state.pet.acc.splice(i,1); else state.pet.acc.push(a); saveState(state); initPet(); }); accList.appendChild(btn); });
+  }
 }
 
 // ---- settings

--- a/styles.css
+++ b/styles.css
@@ -122,6 +122,9 @@ input, textarea, select{ width:100%; background:var(--surface); color:var(--text
 @keyframes bob { 0%,100%{ transform: translateY(0)} 50%{ transform: translateY(-6px) } }
 .stats{ opacity:.9; display:flex; gap:1rem; flex-wrap:wrap }
 
+.toddler-actions{ display:flex; gap:1rem; justify-content:center; margin-top:1rem }
+.toddler-actions button{ font-size:1.4rem; padding:1rem 1.5rem; flex:1 }
+
 /* Ambient grid glow */
 body::before{
   content:""; position:fixed; inset:0; pointer-events:none;


### PR DESCRIPTION
## Summary
- Hide pet renaming, species selection, and accessories when toddler mode is enabled
- Introduce large Feed and Play buttons that grant small XP and gold rewards
- Style new toddler action buttons

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b70ff78ce88326a627a7219b630eb2