### PR TITLE
Sync toddler setting with co-op toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -271,7 +271,13 @@ function initCoop(){
   }
   draw();
   $("#addSidekick").addEventListener("click",()=>{ const t=$("#newSidekick").value.trim(); if(!t) return; state.log.coop.quests.push({title:t,done:false}); $("#newSidekick").value=""; saveState(state); draw(); });
-  $("#toggleWeek").addEventListener("click",()=>{ state.log.coop.toddlerWeek=!state.log.coop.toddlerWeek; saveState(state); $("#coopWeek").textContent = state.log.coop.toddlerWeek? "Toddler Week" : "Solo Week"; });
+  $("#toggleWeek").addEventListener("click",()=>{
+    state.log.coop.toddlerWeek = !state.log.coop.toddlerWeek;
+    state.settings.toddler = state.log.coop.toddlerWeek;
+    renderHUD();
+    saveState(state);
+    $("#coopWeek").textContent = state.log.coop.toddlerWeek? "Toddler Week" : "Solo Week";
+  });
 }
 
 // ---- budget


### PR DESCRIPTION
## Summary
- Update #toggleWeek handler to mirror toddlerWeek into global settings
- Refresh HUD immediately when toggling toddler week
- Persist combined toddler flags to storage

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b717a15b28832688bb07e58f87be63