### PR TITLE
feat: allow reopening journal entries

### DIFF
--- a/app.js
+++ b/app.js
@@ -383,12 +383,27 @@ function initCheckin(){
 }
 
 // ---- journal
-const PROMPTS = ["Name one tiny win from today.","What do you need less of right now?","Three things you’re grateful for:","What would kindness toward yourself look like today?","Finish this sentence: I feel most like me when…","A thought to let go:","A place that makes you breathe easier:","Something you’re proud of this week:"];
+let journalEditId=null;
+const PROMPTS=["Name one tiny win from today.","What do you need less of right now?","Three things you’re grateful for:","What would kindness toward yourself look like today?","Finish this sentence: I feel most like me when…","A thought to let go:","A place that makes you breathe easier:","Something you’re proud of this week:"];
 function initJournal(){
-  const sel=$("#journalPrompt"); sel.replaceChildren(...PROMPTS.map(p=> el("option",{value:p, textContent:p})));
-  $("#newPrompt").addEventListener("click",()=>{ sel.value = PROMPTS[Math.floor(Math.random()*PROMPTS.length)]; });
-  $("#saveJournal").addEventListener("click",()=>{ const prompt=sel.value; const text=$("#journalText").value.trim(); if(!text) return; state.log.journal.push({ id: crypto.randomUUID(), ts: Date.now(), prompt, text }); touchStreak(state); addXP(state,6); addGold(GOLD_REWARD.journal); saveState(state); initJournal(); });
-  const list=$("#journalList"); list.replaceChildren(); state.log.journal.slice().reverse().forEach(j=> list.appendChild(el("div",{className:"quest-row"},[ el("strong",{textContent:fmtDate(j.ts)}), el("span",{textContent:" — "+j.prompt}), el("div",{textContent:j.text}) ])));
+  const sel=$("#journalPrompt"), txt=$("#journalText"), saveBtn=$("#saveJournal");
+  sel.replaceChildren(...PROMPTS.map(p=> el("option",{value:p, textContent:p})));
+  $("#newPrompt").addEventListener("click",()=>{ sel.value=PROMPTS[Math.floor(Math.random()*PROMPTS.length)]; });
+  saveBtn.textContent=journalEditId?"Update":"Save";
+  saveBtn.addEventListener("click",()=>{
+    const prompt=sel.value; const text=txt.value.trim(); if(!text) return;
+    if(journalEditId){ const j=state.log.journal.find(x=>x.id===journalEditId); if(j){ j.prompt=prompt; j.text=text; } journalEditId=null; }
+    else { state.log.journal.push({ id:crypto.randomUUID(), ts:Date.now(), prompt, text }); touchStreak(state); addXP(state,6); addGold(GOLD_REWARD.journal); }
+    saveState(state); initJournal();
+  });
+  const list=$("#journalList"); list.replaceChildren();
+  state.log.journal.slice().reverse().forEach(j=>{
+    const row=el("div",{className:"quest-row"},[ el("strong",{textContent:fmtDate(j.ts)}), el("span",{textContent:" — "+j.prompt}) ]);
+    const btn=el("button",{className:"secondary", textContent:"Open"});
+    btn.addEventListener("click",()=>{ journalEditId=j.id; sel.value=j.prompt; txt.value=j.text; saveBtn.textContent="Update"; });
+    row.appendChild(btn); list.appendChild(row);
+  });
+  $("#journalStorage").textContent="Entries are stored locally in your browser.";
 }
 
 // ---- minigames

--- a/index.html
+++ b/index.html
@@ -273,6 +273,7 @@
       <label class="field"><span>Entry</span><textarea id="journalText" rows="8" placeholder="Let it out…"></textarea></label>
       <div class="row"><button id="saveJournal" class="primary">Save</button><button id="newPrompt" class="secondary">New prompt</button></div>
       <div id="journalList" class="list"></div>
+      <small id="journalStorage"></small>
     </section>
   </template>
 

--- a/main.js
+++ b/main.js
@@ -169,30 +169,31 @@ function initBreathe(){
   $("#stopBreath").addEventListener("click", ()=>{ if(stop){ stop(); stop=null; } });
 }
 
+let journalEditId = null;
 function initJournal(){
-  const sel = $("#journalPrompt");
+  const sel=$("#journalPrompt"), txt=$("#journalText"), saveBtn=$("#saveJournal");
   sel.replaceChildren(...PROMPTS.map(p=> el("option",{value:p, textContent:p})));
-  $("#newPrompt").addEventListener("click", ()=>{
-    const i = Math.floor(Math.random()*PROMPTS.length);
-    sel.value = PROMPTS[i];
-  });
-  $("#saveJournal").addEventListener("click", ()=>{
-    const prompt = sel.value; const text = $("#journalText").value.trim();
-    if(!text) return;
-    state.log.journal.push({ id: crypto.randomUUID(), ts: Date.now(), prompt, text });
-    touchStreak(state); addXP(state, 6);
+  $("#newPrompt").addEventListener("click",()=>{ const i=Math.floor(Math.random()*PROMPTS.length); sel.value=PROMPTS[i]; });
+  saveBtn.textContent=journalEditId?"Update":"Save";
+  saveBtn.addEventListener("click",()=>{
+    const prompt=sel.value; const text=txt.value.trim(); if(!text) return;
+    if(journalEditId){ const e=state.log.journal.find(x=>x.id===journalEditId); if(e){ e.prompt=prompt; e.text=text; } journalEditId=null; }
+    else { state.log.journal.push({ id:crypto.randomUUID(), ts:Date.now(), prompt, text }); touchStreak(state); addXP(state,6); }
     saveState(state); renderRoute();
   });
-  const list = $("#journalList");
+  const list=$("#journalList"); list.replaceChildren();
   state.log.journal.slice().reverse().forEach(j=>{
-    list.appendChild(el("div",{className:"card"},[
+    const row=el("div",{className:"card"},[
       el("div",{className:"row"},[
-        el("strong",{textContent: fmtDate(j.ts)}),
-        el("span",{textContent: " — "+j.prompt})
-      ]),
-      el("div",{textContent: j.text})
-    ]));
+        el("strong",{textContent:fmtDate(j.ts)}),
+        el("span",{textContent:" — "+j.prompt})
+      ])
+    ]);
+    const btn=el("button",{className:"secondary", textContent:"Open"});
+    btn.addEventListener("click",()=>{ journalEditId=j.id; sel.value=j.prompt; txt.value=j.text; saveBtn.textContent="Update"; });
+    row.appendChild(btn); list.appendChild(row);
   });
+  $("#journalStorage").textContent="Entries are stored locally in your browser.";
 }
 
 function initPet(){


### PR DESCRIPTION
## Summary
- list and open previous journal entries for editing
- explain that journal data is stored locally

## Testing
- `node --check app.js`
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b719e684988326acab26af3ba42a79