### PR TITLE
Reduce HUD avatar tile size to 50x50

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,7 @@ input, textarea, select{ width:100%; background:var(--surface); color:var(--text
 .xp-bar.big>div{ height:100% }
 .hud .gold{ font-weight:900; letter-spacing:.5px }
 .avatars{ display:flex; align-items:center; gap:.25rem }
-.avatars .avatar{ width:500px; height:500px; border-radius:8px; overflow:hidden; border:2px solid rgba(255,255,255,.16); box-shadow:0 0 10px rgba(0,0,0,.3) }
+.avatars .avatar{ width:50px; height:50px; border-radius:8px; overflow:hidden; border:2px solid rgba(255,255,255,.16); box-shadow:0 0 10px rgba(0,0,0,.3) }
 .avatars .avatar img{ width:100%; height:100%; object-fit:cover; image-rendering:pixelated }
 
 .char-grid, .comp-grid{ display:flex; flex-wrap:wrap; gap:1rem; justify-content:center }
@@ -66,7 +66,7 @@ input, textarea, select{ width:100%; background:var(--surface); color:var(--text
 .char-card img, .comp-card img{ width:100%; height:auto; border-radius:12px }
 
 .party-banner{ display:flex; gap:1rem; justify-content:center; align-items:center; margin-bottom:1rem }
-.party-member{ width:500px; height:500px; overflow:hidden }
+.party-member{ width:50px; height:50px; overflow:hidden }
 .party-member img{ width:100%; height:100%; object-fit:contain }
 @keyframes wave{ 0%,100%{ transform:translateY(0)} 50%{ transform:translateY(-12px) } }
 @keyframes dance{ 0%,100%{ transform:rotate(-6deg)} 50%{ transform:rotate(6deg) } }


### PR DESCRIPTION
## Summary
- Shrink player, companion, and toddler pet HUD avatars to 50x50px.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7213d7b288326879d0bc898ee807b