### PR TITLE
Restore toddler mode pet rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // ====== SootheBirb v2.5.0 — Characters + Economy ======
 
-import { petSVG, ALL_ACC } from './pet.js';
+import { petSVG, petPixelSVG, ALL_ACC } from './pet.js';
 
 // ------ store (localStorage)
 const KEY = "soothebirb.v25";

--- a/pet.js
+++ b/pet.js
@@ -28,6 +28,17 @@ export function petSVG(species, level, acc=[]){
   </svg>`;
 }
 
+// Pixel-art variant used by certain UI views. This keeps the rendering simple
+// and leverages the existing vector pet while forcing pixelated rendering so
+// it matches the app's retro aesthetic. Having this helper prevents runtime
+// reference errors when toddler mode is enabled.
+export function petPixelSVG(species, level, acc = []) {
+  return petSVG(species, level, acc).replace(
+    '<svg',
+    '<svg style="image-rendering:pixelated"'
+  );
+}
+
 function accessories(list){
   const set = new Set(list);
   let s = "";


### PR DESCRIPTION
## Summary
- Add `petPixelSVG` helper and import to prevent runtime errors when toddler mode is active
- Ensure pixel-style pet rendering uses existing SVG with pixelated styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b721ead88c832690433279e9a501a3