### PR TITLE
fix: add missing petPixelSVG helper

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // ====== SootheBirb v2.5.0 — Characters + Economy ======
 
-import { petSVG, ALL_ACC } from './pet.js';
+import { petSVG, petPixelSVG, ALL_ACC } from './pet.js';
 
 // ------ store (localStorage)
 const KEY = "soothebirb.v25";

--- a/pet.js
+++ b/pet.js
@@ -43,3 +43,13 @@ export const ALL_ACC = [
   { id:"cap", name:"Cap" }, { id:"bow", name:"Bow" }, { id:"glasses", name:"Glasses" },
   { id:"leaf", name:"Leaf" }, { id:"star", name:"Star" }
 ];
+
+// Pixel-art rendering for companions.
+// Currently this simply reuses the main SVG renderer but forces crisp edges
+// so the output has a retro, pixelated look. It acts as a drop-in replacement
+// for the previously undefined function referenced throughout the app.
+export function petPixelSVG(species, level, acc = []) {
+  // Use the existing vector renderer and tweak the SVG to prefer crisp edges
+  // which makes the art appear pixelated when scaled up.
+  return petSVG(species, level, acc).replace('<svg', '<svg shape-rendering="crispEdges"');
+}


### PR DESCRIPTION
## Summary
- implement `petPixelSVG` helper using existing renderer with crisp edges
- import helper to prevent reference error on character page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72186e2fc83268b26a2fa59d6206e