### PR TITLE
Add reward point exchange

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const KEY = "soothebirb.v25";
 const defaultState = () => ({
   user: { name: "", theme: "retro", font: "press2p", art:"pixel", scanlines:true, character:{ id:'witch', img:null } },
   settings: { toddler:false },
-  economy: { gold: 0, ownedAcc: ['cap','glasses'] },
+  economy: { gold: 0, rewardPts: 0, ownedAcc: ['cap','glasses'] },
   pet: { name: "Pebble", species: "birb", level: 1, xp: 0, acc: ["cap","glasses"] },
   settings: { toddler:false },
   streak: { current: 0, best: 0, lastCheck: "" },
@@ -115,6 +115,7 @@ document.addEventListener('click', function unlock(){ ensureAudio(); document.re
 // economy
 const GOLD_REWARD={main:10,side:6,bonus:4,clean:5,coop:5,budget_inc:6,budget_exp:2,journal:5,breathe:4,checkin:5};
 function addGold(n){ state.economy.gold=Math.max(0,(state.economy.gold||0)+n); SFX.gold(); saveState(state); renderHUD(); }
+function addRewardPts(n){ state.economy.rewardPts=Math.max(0,(state.economy.rewardPts||0)+n); fxReward('+'+n+' pts'); saveState(state); renderHUD(); }
 
 // --- Theme + HUD
 let state; try{ state = loadState(); }catch(e){ console.error('init', e); state=defaultState(); }
@@ -367,12 +368,35 @@ function initRewards(){
     {id:"ten-quests", name:"10 Quests", test:s=>s.log.tasks.filter(t=>t.done).length>=10, ico:"🏅"},
     {id:"budget-boss", name:"Budget Keeper", test:s=>s.log.budget.txns.length>=5, ico:"💰"}
   ];
-  defs.forEach(b=>{ if(!state.log.rewards.badges.find(x=>x.id===b.id) && b.test(state)){ state.log.rewards.badges.push({id:b.id, name:b.name, ts:Date.now()}); } });
+  defs.forEach(b=>{
+    if(!state.log.rewards.badges.find(x=>x.id===b.id) && b.test(state)){
+      state.log.rewards.badges.push({id:b.id, name:b.name, ts:Date.now()});
+      addRewardPts(100);
+    }
+  });
   saveState(state);
   defs.forEach(b=>{
     const unlocked=!!state.log.rewards.badges.find(x=>x.id===b.id);
     grid.appendChild(el("div",{className:"badge "+(unlocked?"":"locked")},[ el("div",{className:"b-ico", textContent:b.ico}), el("div",{className:"b-txt", textContent:b.name}) ]));
   });
+  $("#rewardPts").textContent = `Reward Points: ${state.economy.rewardPts||0}`;
+  $("#rewardToGold").onclick = ()=>{
+    if(state.economy.rewardPts>=100){
+      state.economy.rewardPts-=100;
+      addGold(25);
+      saveState(state);
+      initRewards();
+    }else fxToast("Need 100 points");
+  };
+  $("#rewardToXp").onclick = ()=>{
+    if(state.economy.rewardPts>=100){
+      state.economy.rewardPts-=100;
+      addXP(state,100);
+      saveState(state);
+      renderHUD();
+      initRewards();
+    }else fxToast("Need 100 points");
+  };
 }
 
 // ---- checkin

--- a/index.html
+++ b/index.html
@@ -245,6 +245,13 @@
     <section class="rewards">
       <h2 class="dash">Collectibles & Achievements</h2>
       <div class="badges" id="badgeGrid"></div>
+      <div class="exchange">
+        <p id="rewardPts">Reward Points: 0</p>
+        <div class="row">
+          <button id="rewardToGold" class="secondary">100 pts → 25 gold</button>
+          <button id="rewardToXp" class="secondary">100 pts → 100 XP</button>
+        </div>
+      </div>
     </section>
   </template>
 

--- a/styles.css
+++ b/styles.css
@@ -110,6 +110,10 @@ input, textarea, select{ width:100%; background:var(--surface); color:var(--text
 .badge .b-ico{ font-size:1.6rem }
 .badge .b-txt{ font-size:.9rem; text-align:center }
 
+/* Rewards exchange */
+.rewards .exchange{ margin-top:1rem; text-align:center }
+.rewards .exchange .row{ display:flex; gap:.6rem; justify-content:center; margin-top:.4rem }
+
 /* Breathe */
 .phase{ margin-top:.6rem; opacity:.9 }
 .breathe-stage{ display:grid; place-items:center; gap:.6rem; padding:.6rem 0 }


### PR DESCRIPTION
## Summary
- add reward point currency and helper to state
- allow exchanging 100 points for 25 gold or 100 XP on rewards page
- style rewards exchange section

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b71a8e9d188326aeb1587b5db0a74c