### PR TITLE
fix: remove stray tokens from default state

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,11 +5,9 @@ import { petSVG, petPixelSVG, ALL_ACC } from './pet.js';
 // ------ store (localStorage)
 const KEY = "soothebirb.v25";
 const defaultState = () => ({
-codex/update-defaultstate-and-loadstate
   user: { name: "", theme: "retro", font: "press2p", art:"pixel", scanlines:true,
     character:{ id:'ash', img:'assets/heroes/hero-ash.png', level:1, xp:0, acc:[] },
     companion:{ id:'molly', img:'assets/heroes/comp-molly.png' } },
-main
   settings: { toddler:false },
   economy: { gold: 0, rewardPts: 0, ownedAcc: ['cap','glasses'] },
   pet: { name: "Pebble", species: "birb", level: 1, xp: 0, acc: ["cap","glasses"] },


### PR DESCRIPTION
## Summary
- remove stray tokens accidentally left in default state initializer

## Testing
- `node --check app.js`
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/soothebirb/package.json')


------
https://chatgpt.com/codex/tasks/task_e_68b726278d708326b6c00e9446dd0aee